### PR TITLE
Update UserAgent type to include missing platform information

### DIFF
--- a/app/hooks/types.ts
+++ b/app/hooks/types.ts
@@ -53,8 +53,13 @@ export type SafeArea = {
 
 export type DeviceType = "mobile" | "tablet" | "desktop" | "unknown";
 
+export type Platform = "native" | "web";
+
 export type UserAgent = {
-  device: { type: DeviceType };
+  device: {
+    type: DeviceType;
+    platform: Platform;
+  };
   capabilities: {
     hover: boolean;
     touch: boolean;

--- a/app/hooks/types.ts
+++ b/app/hooks/types.ts
@@ -53,7 +53,7 @@ export type SafeArea = {
 
 export type DeviceType = "mobile" | "tablet" | "desktop" | "unknown";
 
-export type Platform = "native" | "web";
+export type Platform = "native" | "web" | "unknown";
 
 export type UserAgent = {
   device: {


### PR DESCRIPTION
Added `device.platform` to the UserAgent type as it is a valid property of `window.openai.userAgent` and essential for device context.